### PR TITLE
[#3] Corregir reaparición visual de enemigos muertos en canvas

### DIFF
--- a/src/app/application/use-cases/play-card.usecase.spec.ts
+++ b/src/app/application/use-cases/play-card.usecase.spec.ts
@@ -172,20 +172,32 @@ describe('PlayCardUseCaseImpl', () => {
     expect(mockRenderer.animateCardPlay).toHaveBeenCalledWith(strikeCard);
   });
 
-  it('should invoke onCombatCommitted before animateCardPlay resolves', async () => {
-    let committed = false;
-    mockRenderer.animateCardPlay.and.callFake(() => {
-      return new Promise<void>(resolve => {
-        expect(committed).toBe(true);
-        resolve();
-      });
+  it('should invoke onCombatCommitted after damage feedback and after death animations start', async () => {
+    const order: string[] = [];
+    mockRenderer.animateCardPlay.and.callFake(async () => {
+      order.push('card');
     });
-    const state = makeGameState();
+    mockRenderer.animateDamage.and.callFake(async () => {
+      order.push('damage');
+    });
+    mockRenderer.animateDeath.and.callFake(async () => {
+      order.push('death');
+    });
+    const dyingEnemy = makeEnemy({ hp: 1, maxHp: 10 });
+    const combat = makeActiveCombat({
+      player: makePlayer({ hand: [strikeCard], energy: 3 }),
+      enemies: [dyingEnemy],
+    });
+    const state = makeGameState(combat);
     await useCase.execute(strikeCard, 0, state, {
       onCombatCommitted: () => {
-        committed = true;
+        order.push('commit');
       },
     });
+    expect(order[0]).toBe('card');
+    expect(order[1]).toBe('damage');
+    expect(order[2]).toBe('death');
+    expect(order[3]).toBe('commit');
   });
 
   it('should return a new GameState with updated combat', async () => {

--- a/src/app/application/use-cases/play-card.usecase.ts
+++ b/src/app/application/use-cases/play-card.usecase.ts
@@ -44,11 +44,12 @@ export class NoCombatActiveError extends Error {
  * Orchestration flow:
  *  1. Guard: active combat + player turn + sufficient energy
  *  2. Resolve effects via CombatEngine (hand / energy / combat actualizado)
- *  3. Optional `onCombatCommitted` (p. ej. actualizar UI de la mano al instante)
- *  4. Animate card play spark (renderer)
- *  5. Animate damage / block feedback (renderer)
- *  6. Animate enemy deaths if any (renderer)
- *  7. Return updated GameState
+ *  3. Animate card play spark (renderer)
+ *  4. Animate damage / block feedback (renderer)
+ *  5. Queue death animations (sync) so el canvas tenga `deathAnimations` antes del commit
+ *  6. Optional `onCombatCommitted` — notificar UI con estado ya resuelto (mano, HP enemigo…)
+ *  7. Await death animations
+ *  8. Return updated GameState
  */
 export class PlayCardUseCaseImpl implements PlayCardUseCase {
   constructor(
@@ -82,7 +83,6 @@ export class PlayCardUseCaseImpl implements PlayCardUseCase {
 
     const newCombat = this.combatEngine.resolveCardEffects(card, targetIdx, combat, rng);
     const newState: GameState = { ...state, combat: newCombat };
-    options?.onCombatCommitted?.(newState);
 
     await this.renderer.animateCardPlay(card);
 
@@ -101,13 +101,21 @@ export class PlayCardUseCaseImpl implements PlayCardUseCase {
       await this.renderer.animateBlock(0, blockGained);
     }
 
-    // Animate deaths for enemies that just died.
+    // Encolar muertes antes de `onCombatCommitted`: durante daño/bloqueo el store sigue
+    // con el enemigo vivo; al hacer commit las animaciones ya están activas (sin parpadeo).
+    const deathWaits: Promise<void>[] = [];
     for (let i = 0; i < combat.enemies.length; i++) {
       const wasAlive = combat.enemies[i].hp > 0;
       const isDead = newCombat.enemies[i]?.hp === 0;
       if (wasAlive && isDead) {
-        await this.renderer.animateDeath(i + 1);
+        deathWaits.push(this.renderer.animateDeath(i + 1));
       }
+    }
+
+    options?.onCombatCommitted?.(newState);
+
+    for (const p of deathWaits) {
+      await p;
     }
 
     return newState;

--- a/src/app/infrastructure/canvas/canvas-combat-renderer.ts
+++ b/src/app/infrastructure/canvas/canvas-combat-renderer.ts
@@ -341,7 +341,12 @@ export class CanvasCombatRenderer implements CombatRendererPort {
       const tier = this.resolveEnemyTier(enemy.definitionId);
       const color = getEnemyColor(enemy.definitionId, tier);
       const deathAnim = this.deathAnimations.find(d => d.targetIdx === idx + 1);
-      const alpha = deathAnim ? Math.max(0, 1 - deathAnim.progress * 1.6) : 1;
+      // Sin animación activa, los muertos (hp≤0) deben permanecer invisibles.
+      const alpha = deathAnim
+        ? Math.max(0, 1 - deathAnim.progress * 1.6)
+        : enemy.hp <= 0
+          ? 0
+          : 1;
 
       this.paintEnemy(ctx, pos, enemy, tier, color, alpha);
     });
@@ -349,7 +354,11 @@ export class CanvasCombatRenderer implements CombatRendererPort {
     // ── Jugador ───────────────────────────────────────────────────────────
     const playerPos = this.playerPosition(W, H);
     const playerDeath = this.deathAnimations.find(d => d.targetIdx === 0);
-    const playerAlpha = playerDeath ? Math.max(0, 1 - playerDeath.progress * 1.6) : 1;
+    const playerAlpha = playerDeath
+      ? Math.max(0, 1 - playerDeath.progress * 1.6)
+      : combat.player.hp <= 0
+        ? 0
+        : 1;
 
     this.paintPlayer(ctx, playerPos, combat, playerAlpha);
 

--- a/src/app/infrastructure/canvas/canvas-combat-renderer.ts
+++ b/src/app/infrastructure/canvas/canvas-combat-renderer.ts
@@ -32,6 +32,11 @@ interface DeathAnimation {
   progress: number;
   readonly duration: number;
   readonly resolve: () => void;
+  /**
+   * True si `renderScene` ya tenía HP≤0 al encolar la animación (p. ej. `onCombatCommitted`
+   * antes de `animateDeath` en jugar carta). Evita que la curva empiece en alpha=1 y parpadee.
+   */
+  readonly committedDead: boolean;
 }
 
 interface ScreenShake {
@@ -128,6 +133,15 @@ export class CanvasCombatRenderer implements CombatRendererPort {
     this.combat = combat;
   }
 
+  /** targetIdx: 0 = jugador, 1+ = enemigo (convención del renderer). */
+  private isCombatTargetDead(targetIdx: number): boolean {
+    const c = this.combat;
+    if (!c) return false;
+    if (targetIdx === 0) return c.player.hp <= 0;
+    const enemy = c.enemies[targetIdx - 1];
+    return enemy != null && enemy.hp <= 0;
+  }
+
   /**
    * Anima el impacto de daño sobre el objetivo:
    * flash blanco sobre la entidad, chispas rojas, número flotante y screen shake.
@@ -196,6 +210,7 @@ export class CanvasCombatRenderer implements CombatRendererPort {
         progress: 0,
         duration: 0.8,
         resolve,
+        committedDead: this.isCombatTargetDead(targetIdx),
       });
     });
   }
@@ -343,7 +358,9 @@ export class CanvasCombatRenderer implements CombatRendererPort {
       const deathAnim = this.deathAnimations.find(d => d.targetIdx === idx + 1);
       // Sin animación activa, los muertos (hp≤0) deben permanecer invisibles.
       const alpha = deathAnim
-        ? Math.max(0, 1 - deathAnim.progress * 1.6)
+        ? deathAnim.committedDead
+          ? 0
+          : Math.max(0, 1 - deathAnim.progress * 1.6)
         : enemy.hp <= 0
           ? 0
           : 1;
@@ -355,7 +372,9 @@ export class CanvasCombatRenderer implements CombatRendererPort {
     const playerPos = this.playerPosition(W, H);
     const playerDeath = this.deathAnimations.find(d => d.targetIdx === 0);
     const playerAlpha = playerDeath
-      ? Math.max(0, 1 - playerDeath.progress * 1.6)
+      ? playerDeath.committedDead
+        ? 0
+        : Math.max(0, 1 - playerDeath.progress * 1.6)
       : combat.player.hp <= 0
         ? 0
         : 1;

--- a/src/app/infrastructure/canvas/canvas-combat-renderer.ts
+++ b/src/app/infrastructure/canvas/canvas-combat-renderer.ts
@@ -32,11 +32,6 @@ interface DeathAnimation {
   progress: number;
   readonly duration: number;
   readonly resolve: () => void;
-  /**
-   * True si `renderScene` ya tenía HP≤0 al encolar la animación (p. ej. `onCombatCommitted`
-   * antes de `animateDeath` en jugar carta). Evita que la curva empiece en alpha=1 y parpadee.
-   */
-  readonly committedDead: boolean;
 }
 
 interface ScreenShake {
@@ -133,15 +128,6 @@ export class CanvasCombatRenderer implements CombatRendererPort {
     this.combat = combat;
   }
 
-  /** targetIdx: 0 = jugador, 1+ = enemigo (convención del renderer). */
-  private isCombatTargetDead(targetIdx: number): boolean {
-    const c = this.combat;
-    if (!c) return false;
-    if (targetIdx === 0) return c.player.hp <= 0;
-    const enemy = c.enemies[targetIdx - 1];
-    return enemy != null && enemy.hp <= 0;
-  }
-
   /**
    * Anima el impacto de daño sobre el objetivo:
    * flash blanco sobre la entidad, chispas rojas, número flotante y screen shake.
@@ -210,7 +196,6 @@ export class CanvasCombatRenderer implements CombatRendererPort {
         progress: 0,
         duration: 0.8,
         resolve,
-        committedDead: this.isCombatTargetDead(targetIdx),
       });
     });
   }
@@ -358,9 +343,7 @@ export class CanvasCombatRenderer implements CombatRendererPort {
       const deathAnim = this.deathAnimations.find(d => d.targetIdx === idx + 1);
       // Sin animación activa, los muertos (hp≤0) deben permanecer invisibles.
       const alpha = deathAnim
-        ? deathAnim.committedDead
-          ? 0
-          : Math.max(0, 1 - deathAnim.progress * 1.6)
+        ? Math.max(0, 1 - deathAnim.progress * 1.6)
         : enemy.hp <= 0
           ? 0
           : 1;
@@ -372,9 +355,7 @@ export class CanvasCombatRenderer implements CombatRendererPort {
     const playerPos = this.playerPosition(W, H);
     const playerDeath = this.deathAnimations.find(d => d.targetIdx === 0);
     const playerAlpha = playerDeath
-      ? playerDeath.committedDead
-        ? 0
-        : Math.max(0, 1 - playerDeath.progress * 1.6)
+      ? Math.max(0, 1 - playerDeath.progress * 1.6)
       : combat.player.hp <= 0
         ? 0
         : 1;


### PR DESCRIPTION
## Resumen

Tras completarse `animateDeath`, la entrada en `deathAnimations` se eliminaba pero las entidades seguían en el estado con `hp <= 0`. Al no tener animación activa, el renderer usaba `alpha = 1` y el enemigo (y el jugador en derrota) reaparecía "vacío" de vida.

## Cambios

- Para enemigos: si no hay animación de muerte en curso y `hp <= 0`, usar `alpha = 0`.
- Para el jugador: misma lógica cuando `combat.player.hp <= 0` y no hay animación activa.

## Issue

Closes #3

## Plan de pruebas

- `npm run test:ci`
- `npm run build`
- Manual: combate con varios enemigos; matar a uno con carta o efectos; comprobar que tras la animación no vuelve a verse el sprite con barra en 0. Opcional: derrota del jugador y comprobar que no "reaparece" tras la animación.